### PR TITLE
Make vault run as the vault user instead of root

### DIFF
--- a/0.6.1/Dockerfile
+++ b/0.6.1/Dockerfile
@@ -8,8 +8,13 @@ ENV VAULT_VERSION=0.6.1
 # to provide HashiCorp-built versions of basic utilities like dumb-init and gosu.
 ENV DOCKER_BASE_VERSION=0.0.4
 
+# Create a vault user and group first so the IDs get set the same way,
+# even as the rest of this may change over time.
+RUN addgroup vault && \
+adduser -S -G vault vault
+
 # Set up certificates, our base tools, and Vault.
-RUN apk add --no-cache ca-certificates gnupg openssl && \
+RUN apk add --no-cache ca-certificates gnupg openssl libcap && \
     gpg --recv-keys 91A6E7F85D05C65630BEF18951852D87348FFC4C && \
     mkdir -p /tmp/build && \
     cd /tmp/build && \
@@ -26,6 +31,7 @@ RUN apk add --no-cache ca-certificates gnupg openssl && \
     gpg --batch --verify vault_${VAULT_VERSION}_SHA256SUMS.sig vault_${VAULT_VERSION}_SHA256SUMS && \
     grep vault_${VAULT_VERSION}_linux_amd64.zip vault_${VAULT_VERSION}_SHA256SUMS | sha256sum -c && \
     unzip -d /bin vault_${VAULT_VERSION}_linux_amd64.zip && \
+    setcap cap_ipc_lock=+ep $(readlink -f $(which vault)) && \
     cd /tmp && \
     rm -rf /tmp/build && \
     apk del gnupg openssl && \
@@ -38,7 +44,8 @@ RUN apk add --no-cache ca-certificates gnupg openssl && \
 # location.
 RUN mkdir -p /vault/logs && \
     mkdir -p /vault/file && \
-    mkdir -p /vault/config
+    mkdir -p /vault/config && \
+    chown -R vault:vault /vault
 
 # Expose the logs directory as a volume since there's potentially long-running
 # state in there

--- a/0.6.1/Dockerfile
+++ b/0.6.1/Dockerfile
@@ -44,8 +44,7 @@ RUN apk add --no-cache ca-certificates gnupg openssl libcap && \
 # location.
 RUN mkdir -p /vault/logs && \
     mkdir -p /vault/file && \
-    mkdir -p /vault/config && \
-    chown -R vault:vault /vault
+    mkdir -p /vault/config
 
 # Expose the logs directory as a volume since there's potentially long-running
 # state in there

--- a/0.6.1/Dockerfile
+++ b/0.6.1/Dockerfile
@@ -11,7 +11,7 @@ ENV DOCKER_BASE_VERSION=0.0.4
 # Create a vault user and group first so the IDs get set the same way,
 # even as the rest of this may change over time.
 RUN addgroup vault && \
-    adduser -S -G vault vault
+adduser -S -G vault vault
 
 # Set up certificates, our base tools, and Vault.
 RUN apk add --no-cache ca-certificates gnupg openssl libcap && \

--- a/0.6.1/Dockerfile
+++ b/0.6.1/Dockerfile
@@ -11,7 +11,7 @@ ENV DOCKER_BASE_VERSION=0.0.4
 # Create a vault user and group first so the IDs get set the same way,
 # even as the rest of this may change over time.
 RUN addgroup vault && \
-adduser -S -G vault vault
+    adduser -S -G vault vault
 
 # Set up certificates, our base tools, and Vault.
 RUN apk add --no-cache ca-certificates gnupg openssl libcap && \

--- a/0.6.1/docker-entrypoint.sh
+++ b/0.6.1/docker-entrypoint.sh
@@ -61,4 +61,9 @@ elif vault --help "$1" 2>&1 | grep -q "vault $1"; then
     set -- vault "$@"
 fi
 
+# If we are running Vault, make sure it executes as the proper user.
+if [ "$1" = 'vault' ]; then
+        set -- gosu vault "$@"
+    fi
+
 exec "$@"

--- a/0.6.1/docker-entrypoint.sh
+++ b/0.6.1/docker-entrypoint.sh
@@ -31,6 +31,7 @@ containsDev () {
     local e
     for e in "${@:1}"; do
         [[ "$e" == "dev" ]] && return 0
+        [[ "$e" == "-dev" ]] && return 0
     done
     return 1
 }

--- a/0.6.3/Dockerfile
+++ b/0.6.3/Dockerfile
@@ -8,8 +8,13 @@ ENV VAULT_VERSION=0.6.3
 # to provide HashiCorp-built versions of basic utilities like dumb-init and gosu.
 ENV DOCKER_BASE_VERSION=0.0.4
 
+# Create a vault user and group first so the IDs get set the same way,
+# even as the rest of this may change over time.
+RUN addgroup vault && \
+    adduser -S -G vault vault
+
 # Set up certificates, our base tools, and Vault.
-RUN apk add --no-cache ca-certificates gnupg openssl && \
+RUN apk add --no-cache ca-certificates gnupg openssl libcap && \
     gpg --recv-keys 91A6E7F85D05C65630BEF18951852D87348FFC4C && \
     mkdir -p /tmp/build && \
     cd /tmp/build && \
@@ -26,6 +31,7 @@ RUN apk add --no-cache ca-certificates gnupg openssl && \
     gpg --batch --verify vault_${VAULT_VERSION}_SHA256SUMS.sig vault_${VAULT_VERSION}_SHA256SUMS && \
     grep vault_${VAULT_VERSION}_linux_amd64.zip vault_${VAULT_VERSION}_SHA256SUMS | sha256sum -c && \
     unzip -d /bin vault_${VAULT_VERSION}_linux_amd64.zip && \
+    setcap cap_ipc_lock=+ep $(readlink -f $(which vault)) && \
     cd /tmp && \
     rm -rf /tmp/build && \
     apk del gnupg openssl && \

--- a/0.6.3/docker-entrypoint.sh
+++ b/0.6.3/docker-entrypoint.sh
@@ -40,4 +40,12 @@ elif vault --help "$1" 2>&1 | grep -q "vault $1"; then
     set -- vault "$@"
 fi
 
+# If we are running Vault, make sure it executes as the proper user.
+if [ "$1" = 'vault' ]; then
+	# vault now runs as a user: make sure to chown bind mounted /vault data.
+	chown -R vault:vault /vault
+
+    set -- gosu vault "$@"
+fi
+
 exec "$@"

--- a/0.6/docker-entrypoint.sh
+++ b/0.6/docker-entrypoint.sh
@@ -36,6 +36,7 @@ containsDev () {
     local e
     for e in "${@:1}"; do
         [[ "$e" == "dev" ]] && return 0
+        [[ "$e" == "-dev" ]] && return 0
     done
     return 1
 }


### PR DESCRIPTION
Using the consul Dockerfile, I tried to use the same method to make vault run as a user.
setcap was installed and used to give vault the IPC_LOCK capability required to lock memory.

edit: https://www.vaultproject.io/docs/config/ mentions how to do the setcap I used :)
