### PR TITLE
Allow containers to be started without IPC_LOCK

### DIFF
--- a/0.6.3/docker-entrypoint.sh
+++ b/0.6.3/docker-entrypoint.sh
@@ -74,4 +74,10 @@ fi
 # Allow mlock to avoid swapping Vault memory to disk
 setcap cap_ipc_lock=+ep $(readlink -f $(which vault))
 
+# In the case vault has been started in a container without IPC_LOCK privileges
+if ! vault -version 2> /dev/null; then
+    2> echo "Couldn't start vault with IPC_LOCK. Disabling IPC_LOCK, please use --privileged or --cap-add IPC_LOCK"
+    setcap -r $(readlink -f $(which vault))
+fi
+
 exec "$@"

--- a/0.6.4/docker-entrypoint.sh
+++ b/0.6.4/docker-entrypoint.sh
@@ -74,4 +74,10 @@ fi
 # Allow mlock to avoid swapping Vault memory to disk
 setcap cap_ipc_lock=+ep $(readlink -f $(which vault))
 
+# In the case vault has been started in a container without IPC_LOCK privileges
+if ! vault -version 2> /dev/null; then
+    2> echo "Couldn't start vault with IPC_LOCK. Disabling IPC_LOCK, please use --privileged or --cap-add IPC_LOCK"
+    setcap -r $(readlink -f $(which vault))
+fi
+ 
 exec "$@"


### PR DESCRIPTION
Allow the container to be started without additional capabilities (see https://github.com/hashicorp/docker-vault/issues/17)