### PR TITLE
Show a warning if vault can't chown /vault/config instead of failing

### DIFF
--- a/0.6.4/docker-entrypoint.sh
+++ b/0.6.4/docker-entrypoint.sh
@@ -65,7 +65,7 @@ fi
 if [ "$1" = 'vault' ]; then
     # If the config dir is bind mounted then chown it
     if [ "$(stat -c %u /vault/config)" != "$(id -u vault)" ]; then
-        chown -R vault:vault /vault/config
+        chown -R vault:vault /vault/config || echo "Could not chown /vault/config do we not have root access to the filesystem?"
     fi
 
     # If the logs dir is bind mounted then chown it

--- a/0.6.4/docker-entrypoint.sh
+++ b/0.6.4/docker-entrypoint.sh
@@ -65,7 +65,7 @@ fi
 if [ "$1" = 'vault' ]; then
     # If the config dir is bind mounted then chown it
     if [ "$(stat -c %u /vault/config)" != "$(id -u vault)" ]; then
-        chown -R vault:vault /vault/config || echo "Could not chown /vault/config do we not have root access to the filesystem?"
+        chown -R vault:vault /vault/config || echo "Could not chown /vault/config (may not have appropriate permissions)"
     fi
 
     # If the logs dir is bind mounted then chown it


### PR DESCRIPTION
The config folder and the files in it don't need to be owned by the vault user, they just need to be readable. 

This fixes issues when the bind mount is a nfs share and cannot change file permissions.