### PR TITLE
Compatibility fix for docker swarm

### DIFF
--- a/0.6.2/docker-entrypoint.sh
+++ b/0.6.2/docker-entrypoint.sh
@@ -6,28 +6,6 @@ set -e
 # wouldn't do either of these functions so we'd leak zombies as well as do
 # unclean termination of all our sub-processes.
 
-
-# Allow setting VAULT_REDIRECT_ADDR and VAULT_CLUSTER_ADDR using an interface
-# name instead of an IP address. The interface name is specified using
-# VAULT_REDIRECT_INTERFACE and VAULT_CLUSTER_INTERFACE environment variables. If
-# VAULT_*_ADDR is also set, the resulting URI will combine the protocol and port
-# number with the IP of the named interface.
-get_addr () {
-    IF_NAME=$1
-    ip addr show dev $IF_NAME | awk -v uri=$2 '/\s*inet\s/ { \
-      ip=gensub(/(.+)\/.+/, "\\1", "g", $2); \
-      print gensub(/^(.+:\/\/).+(:.+)$/, "\\1" ip "\\2", "g", uri)}'
-}
-
-if [ -n "$VAULT_REDIRECT_INTERFACE" ]; then
-    export VAULT_REDIRECT_ADDR=$(get_addr $VAULT_REDIRECT_INTERFACE ${VAULT_REDIRECT_ADDR:-"http://0.0.0.0:8200"})
-    echo "Using $VAULT_REDIRECT_INTERFACE for VAULT_REDIRECT_ADDR: $VAULT_REDIRECT_ADDR"
-fi
-if [ -n "$VAULT_CLUSTER_INTERFACE" ]; then
-    export VAULT_CLUSTER_ADDR=$(get_addr $VAULT_CLUSTER_INTERFACE ${VAULT_CLUSTER_ADDR:-"https://0.0.0.0:8201"})
-    echo "Using $VAULT_CLUSTER_INTERFACE for VAULT_CLUSTER_ADDR: $VAULT_CLUSTER_ADDR"
-fi
-
 # VAULT_CONFIG_DIR isn't exposed as a volume but you can compose additional
 # config files in there if you use this image as a base, or use
 # VAULT_LOCAL_CONFIG below.

--- a/0.6.2/docker-entrypoint.sh
+++ b/0.6.2/docker-entrypoint.sh
@@ -6,6 +6,28 @@ set -e
 # wouldn't do either of these functions so we'd leak zombies as well as do
 # unclean termination of all our sub-processes.
 
+
+# Allow setting VAULT_REDIRECT_ADDR and VAULT_CLUSTER_ADDR using an interface
+# name instead of an IP address. The interface name is specified using
+# VAULT_REDIRECT_INTERFACE and VAULT_CLUSTER_INTERFACE environment variables. If
+# VAULT_*_ADDR is also set, the resulting URI will combine the protocol and port
+# number with the IP of the named interface.
+get_addr () {
+    IF_NAME=$1
+    ip addr show dev $IF_NAME | awk -v uri=$2 '/\s*inet\s/ { \
+      ip=gensub(/(.+)\/.+/, "\\1", "g", $2); \
+      print gensub(/^(.+:\/\/).+(:.+)$/, "\\1" ip "\\2", "g", uri)}'
+}
+
+if [ -n "$VAULT_REDIRECT_INTERFACE" ]; then
+    export VAULT_REDIRECT_ADDR=$(get_addr $VAULT_REDIRECT_INTERFACE ${VAULT_REDIRECT_ADDR:-"http://0.0.0.0:8200"})
+    echo "Using $VAULT_REDIRECT_INTERFACE for VAULT_REDIRECT_ADDR: $VAULT_REDIRECT_ADDR"
+fi
+if [ -n "$VAULT_CLUSTER_INTERFACE" ]; then
+    export VAULT_CLUSTER_ADDR=$(get_addr $VAULT_CLUSTER_INTERFACE ${VAULT_CLUSTER_ADDR:-"https://0.0.0.0:8201"})
+    echo "Using $VAULT_CLUSTER_INTERFACE for VAULT_CLUSTER_ADDR: $VAULT_CLUSTER_ADDR"
+fi
+
 # VAULT_CONFIG_DIR isn't exposed as a volume but you can compose additional
 # config files in there if you use this image as a base, or use
 # VAULT_LOCAL_CONFIG below.

--- a/0.6.5/docker-entrypoint.sh
+++ b/0.6.5/docker-entrypoint.sh
@@ -12,10 +12,12 @@ set -e
 # VAULT_*_ADDR is also set, the resulting URI will combine the protocol and port
 # number with the IP of the named interface.
 get_addr () {
-    IF_NAME=$1
-    ip addr show dev $IF_NAME | awk -v uri=$2 '/\s*inet\s/ { \
+    local if_name=$1
+    local uri_template=$2
+    ip addr show dev $if_name | awk -v uri=$uri_template '/\s*inet\s/ { \
       ip=gensub(/(.+)\/.+/, "\\1", "g", $2); \
-      print gensub(/^(.+:\/\/).+(:.+)$/, "\\1" ip "\\2", "g", uri)}'
+      print gensub(/^(.+:\/\/).+(:.+)$/, "\\1" ip "\\2", "g", uri); \
+      exit}'
 }
 
 if [ -n "$VAULT_REDIRECT_INTERFACE" ]; then


### PR DESCRIPTION
This fixes an issue when using named interfaces in a docker swarm environment, which adds multiple IP addresses to each interface