### PR TITLE
Only remove the IPC_LOCK capability from vault

### DIFF
--- a/0.7.0/docker-entrypoint.sh
+++ b/0.7.0/docker-entrypoint.sh
@@ -87,7 +87,7 @@ if [ "$1" = 'vault' ]; then
         # In the case vault has been started in a container without IPC_LOCK privileges
         if ! vault -version 1>/dev/null 2>/dev/null; then
             >&2 echo "Couldn't start vault with IPC_LOCK. Disabling IPC_LOCK, please use --privileged or --cap-add IPC_LOCK"
-            setcap -r $(readlink -f $(which vault))
+            setcap cap_ipc_lock=-ep $(readlink -f $(which vault))
         fi
     fi
 


### PR DESCRIPTION
Doing a `setcap -r` on vault can lead to failures such as:

```
getcap /bin/vault
Failed to get capabilities of file `/bin/vault' (No error information)
```

or 
```
+ exec gosu vault vault -version
error: exec failed: invalid argument
```

In order to avoid that, only remove the capability IPC_LOCK rather than doing `-r`