### PR TITLE
Make the entrypoint extensible

### DIFF
--- a/0.X/Dockerfile
+++ b/0.X/Dockerfile
@@ -14,7 +14,7 @@ RUN addgroup vault && \
     adduser -S -G vault vault
 
 # Set up certificates, our base tools, and Vault.
-RUN apk add --no-cache ca-certificates gnupg openssl libcap && \
+RUN apk add --no-cache ca-certificates gnupg openssl libcap run-parts && \
     gpg --keyserver pgp.mit.edu --recv-keys 91A6E7F85D05C65630BEF18951852D87348FFC4C && \
     mkdir -p /tmp/build && \
     cd /tmp/build && \
@@ -64,6 +64,7 @@ EXPOSE 8200
 # For production derivatives of this container, you shoud add the IPC_LOCK
 # capability so that Vault can mlock memory.
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+ONBUILD COPY /docker-entrypoint.d/* /docker-entrypoint.d/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 # By default you'll get a single-node development server that stores everything

--- a/0.X/docker-entrypoint.sh
+++ b/0.X/docker-entrypoint.sh
@@ -94,4 +94,9 @@ if [ "$1" = 'vault' ]; then
     set -- gosu vault "$@"
 fi
 
+DIR=/docker-entrypoint.d
+if [ -d "$DIR" ]; then
+    /usr/bin/run-parts --verbose "$DIR"
+fi
+
 exec "$@"


### PR DESCRIPTION
Based on the techniques described at https://www.camptocamp.com/en/actualite/flexible-docker-entrypoints-scripts/

Enable downstream users of the image to mount additional entrypoint
functionality at runtime or optionally build derivative images with extended
functionality via the /docker-entrypoint.d directory