### PR TITLE
Adding curl to Image

### DIFF
--- a/0.X/Dockerfile
+++ b/0.X/Dockerfile
@@ -14,7 +14,7 @@ RUN addgroup vault && \
     adduser -S -G vault vault
 
 # Set up certificates, our base tools, and Vault.
-RUN apk add --no-cache ca-certificates gnupg openssl libcap && \
+RUN apk add --no-cache ca-certificates gnupg openssl libcap curl && \
     gpg --keyserver pgp.mit.edu --recv-keys 91A6E7F85D05C65630BEF18951852D87348FFC4C && \
     mkdir -p /tmp/build && \
     cd /tmp/build && \


### PR DESCRIPTION
I'm interesting in putting together a pipeline to manage vault policies and provisioning, and it would be awesome to be able to use the official image rather then build our own.  I started with trying to work through some of the example I found in @sethvargo [post](https://www.hashicorp.com/blog/codifying-vault-policies-and-configuration)  and found curl missing from the image (although wget is installed) .  