### PR TITLE
Use su-exec and tini from alpine instead of docker-base

### DIFF
--- a/0.X/Dockerfile
+++ b/0.X/Dockerfile
@@ -47,7 +47,7 @@ VOLUME /vault/file
 # Vault.
 EXPOSE 8200
 
-# The entry point script uses tini as the top-level process to reap any
+# The entry point script uses dumb-init as the top-level process to reap any
 # zombie processes created by Vault sub-processes.
 #
 # For production derivatives of this container, you shoud add the IPC_LOCK

--- a/0.X/Dockerfile
+++ b/0.X/Dockerfile
@@ -4,27 +4,16 @@ MAINTAINER Jeff Mitchell <jeff@hashicorp.com> (@jefferai)
 # This is the release of Vault to pull in.
 ENV VAULT_VERSION=0.9.0
 
-# This is the release of https://github.com/hashicorp/docker-base to pull in order
-# to provide HashiCorp-built versions of basic utilities like dumb-init and gosu.
-ENV DOCKER_BASE_VERSION=0.0.4
-
 # Create a vault user and group first so the IDs get set the same way,
 # even as the rest of this may change over time.
 RUN addgroup vault && \
     adduser -S -G vault vault
 
 # Set up certificates, our base tools, and Vault.
-RUN apk add --no-cache ca-certificates gnupg openssl libcap && \
+RUN apk add --no-cache ca-certificates gnupg openssl libcap su-exec tini && \
     gpg --keyserver pgp.mit.edu --recv-keys 91A6E7F85D05C65630BEF18951852D87348FFC4C && \
     mkdir -p /tmp/build && \
     cd /tmp/build && \
-    wget https://releases.hashicorp.com/docker-base/${DOCKER_BASE_VERSION}/docker-base_${DOCKER_BASE_VERSION}_linux_amd64.zip && \
-    wget https://releases.hashicorp.com/docker-base/${DOCKER_BASE_VERSION}/docker-base_${DOCKER_BASE_VERSION}_SHA256SUMS && \
-    wget https://releases.hashicorp.com/docker-base/${DOCKER_BASE_VERSION}/docker-base_${DOCKER_BASE_VERSION}_SHA256SUMS.sig && \
-    gpg --batch --verify docker-base_${DOCKER_BASE_VERSION}_SHA256SUMS.sig docker-base_${DOCKER_BASE_VERSION}_SHA256SUMS && \
-    grep ${DOCKER_BASE_VERSION}_linux_amd64.zip docker-base_${DOCKER_BASE_VERSION}_SHA256SUMS | sha256sum -c && \
-    unzip docker-base_${DOCKER_BASE_VERSION}_linux_amd64.zip && \
-    cp bin/gosu bin/dumb-init /bin && \
     wget https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip && \
     wget https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_SHA256SUMS && \
     wget https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_SHA256SUMS.sig && \
@@ -58,13 +47,13 @@ VOLUME /vault/file
 # Vault.
 EXPOSE 8200
 
-# The entry point script uses dumb-init as the top-level process to reap any
+# The entry point script uses tini as the top-level process to reap any
 # zombie processes created by Vault sub-processes.
 #
 # For production derivatives of this container, you shoud add the IPC_LOCK
 # capability so that Vault can mlock memory.
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
-ENTRYPOINT ["docker-entrypoint.sh"]
+ENTRYPOINT ["/sbin/tini", "--", "docker-entrypoint.sh"]
 
 # By default you'll get a single-node development server that stores everything
 # in RAM and bootstraps itself. Don't use this configuration for production.

--- a/0.X/Dockerfile
+++ b/0.X/Dockerfile
@@ -10,7 +10,7 @@ RUN addgroup vault && \
     adduser -S -G vault vault
 
 # Set up certificates, our base tools, and Vault.
-RUN apk add --no-cache ca-certificates gnupg openssl libcap su-exec tini && \
+RUN apk add --no-cache ca-certificates gnupg openssl libcap su-exec dumb-init && \
     gpg --keyserver pgp.mit.edu --recv-keys 91A6E7F85D05C65630BEF18951852D87348FFC4C && \
     mkdir -p /tmp/build && \
     cd /tmp/build && \
@@ -53,7 +53,7 @@ EXPOSE 8200
 # For production derivatives of this container, you shoud add the IPC_LOCK
 # capability so that Vault can mlock memory.
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
-ENTRYPOINT ["/sbin/tini", "--", "docker-entrypoint.sh"]
+ENTRYPOINT ["docker-entrypoint.sh"]
 
 # By default you'll get a single-node development server that stores everything
 # in RAM and bootstraps itself. Don't use this configuration for production.

--- a/0.X/README.md
+++ b/0.X/README.md
@@ -8,8 +8,5 @@ There are several pieces that are used to build this image:
 * We start with an Alpine base image and add CA certificates in order to reach
   the HashiCorp releases server. These are useful to leave in the image so that
   the container can access Atlas features as well.
-* Official HashiCorp builds of some base utilities are then included in the
-  image by pulling a release of docker-base. This includes dumb-init and gosu.
-  See https://github.com/hashicorp/docker-base for more details.
 * Finally a specific Vault build is fetched and the rest of the Vault-specific
   configuration happens according to the Dockerfile.

--- a/0.X/docker-entrypoint.sh
+++ b/0.X/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/dumb-init /bin/sh
 set -e
 
 # Note above that we run dumb-init as PID 1 in order to reap zombie processes

--- a/0.X/docker-entrypoint.sh
+++ b/0.X/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/dumb-init /bin/sh
+#!/bin/sh
 set -e
 
 # Note above that we run dumb-init as PID 1 in order to reap zombie processes
@@ -91,7 +91,7 @@ if [ "$1" = 'vault' ]; then
         fi
     fi
 
-    set -- gosu vault "$@"
+    set -- su-exec vault "$@"
 fi
 
 exec "$@"


### PR DESCRIPTION
Addresses #63 

In the end I wen't with su-exec instead of gosu, as it's 1) smaller and 2) part of alpine main (gosu is in world)