### PR TITLE
Add disable gosu flag fixes #40

### DIFF
--- a/0.X/docker-entrypoint.sh
+++ b/0.X/docker-entrypoint.sh
@@ -91,7 +91,9 @@ if [ "$1" = 'vault' ]; then
         fi
     fi
 
-    set -- su-exec vault "$@"
+    if [ -z "$DISABLE_SU" ]; then
+      set -- su-exec vault "$@"
+    fi
 fi
 
 exec "$@"


### PR DESCRIPTION
A "keep it simple" fix for disabling gosu when you want to run the image as a docker specified user.

Example systemd start command (note the addition of ulimit memlock for memlock as a non-root user, thanks to the elasticsearch project):

ExecStart=/bin/docker run --name=vault \
                 -d \
                 -u vault \
                 -e SKIP_SETCAP=1 \
                 -e DISABLE_GOSU=1 \
                 -v /vault/config:/vault/config:Z \
                 -v /vault/ssl:/vault/ssl:Z \
                 --net=host \
                 --restart on-failure \
                 --cap-add=IPC_LOCK \
                 --ulimit memlock=819200000:819200000 \
                 vault \
                 server

The original reason for starting to look at this was because the vault user and the consul user are both added to the container as uid 100 btw - but this is a moot point once you can ditch gosu.