### PR TITLE
Avoid race condition

### DIFF
--- a/0.X/Dockerfile
+++ b/0.X/Dockerfile
@@ -30,6 +30,8 @@ RUN set -eux; \
     unzip -d /bin vault_${VAULT_VERSION}_linux_${ARCH}.zip && \
     cd /tmp && \
     rm -rf /tmp/build && \
+    gpgconf --kill dirmngr && \
+    gpgconf --kill gpg-agent && \
     apk del gnupg openssl && \
     rm -rf /root/.gnupg
 


### PR DESCRIPTION
This solves the following error when building this image.
rm: can't remove '/root/.gnupg/S.gpg-agent.ssh': No such file or directory

This is likely due to a race condition when removing a directory that
gpg-agent and dirmanger care about.

Clearly you don't have this issue now as you're able to make builds using whatever your system is today.
Perhaps in the future you switch systems and this race condition manifests itself.  Please merge this harmless pull request ;-)