### PR TITLE
Correctly set file ownership on startup

### DIFF
--- a/0.X/docker-entrypoint.sh
+++ b/0.X/docker-entrypoint.sh
@@ -65,20 +65,9 @@ fi
 
 # If we are running Vault, make sure it executes as the proper user.
 if [ "$1" = 'vault' ]; then
-    # If the config dir is bind mounted then chown it
-    if [ "$(stat -c %u /vault/config)" != "$(id -u vault)" ]; then
-        chown -R vault:vault /vault/config || echo "Could not chown /vault/config (may not have appropriate permissions)"
-    fi
 
-    # If the logs dir is bind mounted then chown it
-    if [ "$(stat -c %u /vault/logs)" != "$(id -u vault)" ]; then
-        chown -R vault:vault /vault/logs
-    fi
-
-    # If the file dir is bind mounted then chown it
-    if [ "$(stat -c %u /vault/file)" != "$(id -u vault)" ]; then
-        chown -R vault:vault /vault/file
-    fi
+    # Ensure all of our permissions are set properly
+    chown -R vault:vault /vault || echo "Could not chown /vault (may not have appropriate permissions)"
 
     if [ -z "$SKIP_SETCAP" ]; then
         # Allow mlock to avoid swapping Vault memory to disk


### PR DESCRIPTION
`[ "$(stat -c %u /vault/config)" != "$(id -u vault)" ]` does not correctly test "If the config dir is bind mounted"

This will break if the user starts vault, then copies an additional file into the bind mounted config directory and then restarts the container. While the folder `/vault/config` will be still owned by vault:vault after the container is restarted, the newly created files will not mirror those permissions unless the sticky bit was set on the directory AND the user didn't inadvertently change them.

The result looks something like this:
```
Error loading configuration from /vault/config: error loading "/vault/config/local.json": open /vault/config/local.json: permission denied
```