### PR TITLE
add `curl' utility to favor vault-operator healthy check

### DIFF
--- a/0.X/Dockerfile
+++ b/0.X/Dockerfile
@@ -10,7 +10,7 @@ RUN addgroup vault && \
 
 # Set up certificates, our base tools, and Vault.
 RUN set -eux; \
-    apk add --no-cache ca-certificates gnupg openssl libcap su-exec dumb-init && \
+    apk add --no-cache ca-certificates gnupg openssl libcap su-exec dumb-init curl && \
     apkArch="$(apk --print-arch)"; \
     case "$apkArch" in \
         armhf) ARCH='arm' ;; \


### PR DESCRIPTION
* vault-operator uses curl command to do liveness probe

* refer to https://github.com/coreos/vault-operator/blob/master/pkg/util/k8sutil/vault.go

Change-Id: I385e72caae1038e45dd89195cfc5faf9aebd3b91