### PR TITLE
Added in --no-tty so gpg can happily retrieve keys in a headless environment

### DIFF
--- a/0.X/Dockerfile
+++ b/0.X/Dockerfile
@@ -27,7 +27,7 @@ RUN set -eux; \
         hkp://pgp.mit.edu:80 \
     ; do \
         echo "Fetching GPG key $VAULT_GPGKEY from $server"; \
-        gpg --keyserver "$server" --recv-keys "$VAULT_GPGKEY" && found=yes && break; \
+        gpg --no-tty --keyserver "$server" --recv-keys "$VAULT_GPGKEY" && found=yes && break; \
     done; \
     test -z "$found" && echo >&2 "error: failed to fetch GPG key $VAULT_GPGKEY" && exit 1; \
     mkdir -p /tmp/build && \


### PR DESCRIPTION
While this option doesn't seem to be strictly necessary at the moment, I'm maintaining a fork of this repo that builds on top of `debian:stretch`, which doesn't seem to have a `/dev/tty` when building the image.

From my tests this option doesn't seem to harm the alpine build, and it may save you some grief at some point if alpine ends up in this same situation in the future.