### PR TITLE
Swap "--no-tty" for "--batch"

### DIFF
--- a/0.X/Dockerfile
+++ b/0.X/Dockerfile
@@ -27,7 +27,7 @@ RUN set -eux; \
         hkp://pgp.mit.edu:80 \
     ; do \
         echo "Fetching GPG key $VAULT_GPGKEY from $server"; \
-        gpg --no-tty --keyserver "$server" --recv-keys "$VAULT_GPGKEY" && found=yes && break; \
+        gpg --batch --keyserver "$server" --recv-keys "$VAULT_GPGKEY" && found=yes && break; \
     done; \
     test -z "$found" && echo >&2 "error: failed to fetch GPG key $VAULT_GPGKEY" && exit 1; \
     mkdir -p /tmp/build && \


### PR DESCRIPTION
See https://bugs.debian.org/913614, especially:

> PS i do encourage everyone who is automating the use of gpg to use --batch everywhere, as this forces GnuPG into a mode that is expected to be used for automation (its "API", for lack of a better term, as opposed to its "UI", which is its normal non-batch mode).

Refs https://github.com/docker-library/official-images/pull/5137#issuecomment-443912162