### PR TITLE
Give Vault mlock syscall without being root

### DIFF
--- a/0.X/Dockerfile
+++ b/0.X/Dockerfile
@@ -45,6 +45,11 @@ RUN set -eux; \
     apk del gnupg openssl && \
     rm -rf /root/.gnupg
 
+# Give the Vault executable the ability to use the mlock syscall 
+# without running the process as root.
+# See https://www.vaultproject.io/docs/configuration/ for details.
+RUN setcap cap_ipc_lock=+ep $(readlink -f $(which vault))
+
 # /vault/logs is made available to use as a location to store audit logs, if
 # desired; /vault/file is made available to use as a location with the file
 # storage backend, if desired; the server will be started with /vault/config as


### PR DESCRIPTION
The container running Vault requires IPC_LOCK
capability to prevent sensitive values from being swapped
to disk. However, in order to be able to leverage this
capability the Vault process either needs to run as root,
or have the mlock syscall permission.

It is best practice to not run privileged containers,
so I'm adding this capability to the Vault executable here.

See https://www.vaultproject.io/docs/configuration/ for details.