### PR TITLE
Add tzdata

### DIFF
--- a/0.X/Dockerfile
+++ b/0.X/Dockerfile
@@ -10,7 +10,7 @@ RUN addgroup vault && \
 
 # Set up certificates, our base tools, and Vault.
 RUN set -eux; \
-    apk add --no-cache ca-certificates gnupg openssl libcap su-exec dumb-init && \
+    apk add --no-cache ca-certificates gnupg openssl libcap su-exec dumb-init tzdata && \
     apkArch="$(apk --print-arch)"; \
     case "$apkArch" in \
         armhf) ARCH='arm' ;; \


### PR DESCRIPTION
alicloudkms  seal

```
panic: open /goroot/lib/time/zoneinfo.zip: no such file or directory

goroutine 1 [running]:
github.com/hashicorp/vault/vendor/github.com/aliyun/alibaba-cloud-sdk-go/sdk/utils.GetTimeInFormatISO8601(0x25cd820, 0xc0006beff0)
	/gopath/src/github.com/hashicorp/vault/vendor/github.com/aliyun/alibaba-cloud-sdk-go/sdk/utils/utils.go:60 +0x140
github.com/hashicorp/vault/vendor/github.com/aliyun/alibaba-cloud-sdk-go/sdk/auth.completeRpcSignParams(0x2f342a0, 0xc0006befc0, 0x2f16ec0, 0xc0001f4068, 0xc00073e4f1, 0xb, 0x0, 0x0)
	/gopath/src/github.com/hashicorp/vault/vendor/github.com/aliyun/alibaba-cloud-sdk-go/sdk/auth/rpc_signature_composer.go:47 +0x1de
github.com/hashicorp/vault/vendor/github.com/aliyun/alibaba-cloud-sdk-go/sdk/auth.signRpcRequest(0x2f342a0, 0xc0006befc0, 0x2f16ec0, 0xc0001f4068, 0xc00073e4f1, 0xb, 0x2f3a120, 0xc000048070)
	/gopath/src/github.com/hashicorp/vault/vendor/github.com/aliyun/alibaba-cloud-sdk-go/sdk/auth/rpc_signature_composer.go:26 +0x73
github.com/hashicorp/vault/vendor/github.com/aliyun/alibaba-cloud-sdk-go/sdk/auth.Sign(0x2f342a0, 0xc0006befc0, 0x2f16ec0, 0xc0001f4068, 0xc00073e4f1, 0xb, 0x8, 0x0)
	/gopath/src/github.com/hashicorp/vault/vendor/github.com/aliyun/alibaba-cloud-sdk-go/sdk/auth/signer.go:87 +0x273
github.com/hashicorp/vault/vendor/github.com/aliyun/alibaba-cloud-sdk-go/sdk.buildHttpRequest(0x2f342a0, 0xc0006befc0, 0x2f16ec0, 0xc0001f4068, 0xc00073e4f1, 0xb, 0xc0006bf050, 0xc000764380, 0x8)
	/gopath/src/github.com/hashicorp/vault/vendor/github.com/aliyun/alibaba-cloud-sdk-go/sdk/client.go:287 +0x84
github.com/hashicorp/vault/vendor/github.com/aliyun/alibaba-cloud-sdk-go/sdk.(*Client).DoActionWithSigner(0xc0006c01e0, 0x2f342a0, 0xc0006befc0, 0x2f17340, 0xc00019e180, 0x0, 0x0, 0x25cd801, 0xc0006bc580)
	/gopath/src/github.com/hashicorp/vault/vendor/github.com/aliyun/alibaba-cloud-sdk-go/sdk/client.go:239 +0x3d2
github.com/hashicorp/vault/vendor/github.com/aliyun/alibaba-cloud-sdk-go/sdk.(*Client).DoAction(0xc0006c01e0, 0x2f342a0, 0xc0006befc0, 0x2f17340, 0xc00019e180, 0xc0006beff0, 0xc0001f4070)
	/gopath/src/github.com/hashicorp/vault/vendor/github.com/aliyun/alibaba-cloud-sdk-go/sdk/client.go:151 +0x5b
github.com/hashicorp/vault/vendor/github.com/aliyun/alibaba-cloud-sdk-go/services/kms.(*Client).DescribeKey(0xc0006c01e0, 0xc0006befc0, 0xc00066a180, 0x23baac0, 0xc00013aaa0)
	/gopath/src/github.com/hashicorp/vault/vendor/github.com/aliyun/alibaba-cloud-sdk-go/services/kms/describe_key.go:27 +0x98
github.com/hashicorp/vault/vault/seal/alicloudkms.(*AliCloudKMSSeal).SetConfig(0xc0006c0190, 0xc00073ce70, 0xc0006c0190, 0xc0007ef0a8, 0x40b8ef)
	/gopath/src/github.com/hashicorp/vault/vault/seal/alicloudkms/alicloudkms.go:125 +0x14f
github.com/hashicorp/vault/command/server/seal.configureAliCloudKMSSeal(0xc00026af00, 0xc00013aa40, 0xc0001f4050, 0x2f25580, 0xc00066a120, 0x2f267a0, 0xc0006bc540, 0xffffffffffffffff, 0xc0006bc501, 0xc0007ef108, ...)
	/gopath/src/github.com/hashicorp/vault/command/server/seal/server_seal_alicloudkms.go:14 +0x75
github.com/hashicorp/vault/command/server/seal.configureSeal(0xc00026af00, 0xc00013aa40, 0xc0001f4050, 0x2f25580, 0xc00066a120, 0x2f267a0, 0xc0006bc540, 0x4, 0xc000655680, 0xc00072b980, ...)
	/gopath/src/github.com/hashicorp/vault/command/server/seal/server_seal.go:26 +0x396
github.com/hashicorp/vault/command.(*ServerCommand).Run(0xc00072bd40, 0xc0000380a0, 0x2, 0x2, 0x0)
	/gopath/src/github.com/hashicorp/vault/command/server.go:507 +0x861c
github.com/hashicorp/vault/vendor/github.com/mitchellh/cli.(*CLI).Run(0xc0006c5e00, 0xc0006c5e00, 0xc00013a840, 0xc00026ab40)
	/gopath/src/github.com/hashicorp/vault/vendor/github.com/mitchellh/cli/cli.go:255 +0x207
github.com/hashicorp/vault/command.RunCustom(0xc000038090, 0x3, 0x3, 0xc0000944b0, 0x0)
	/gopath/src/github.com/hashicorp/vault/command/main.go:170 +0x74a
github.com/hashicorp/vault/command.Run(0xc000038090, 0x3, 0x3, 0xc000086058)
	/gopath/src/github.com/hashicorp/vault/command/main.go:81 +0x48
main.main()
	/gopath/src/github.com/hashicorp/vault/main.go:10 +0x62
```