### PR TITLE
Rename VAULT_VERSION environment variable in Dockerfile

### DIFF
--- a/0.X/Dockerfile
+++ b/0.X/Dockerfile
@@ -1,7 +1,9 @@
 FROM alpine:3.8
 
 # This is the release of Vault to pull in.
-ENV VAULT_VERSION=1.1.0-beta2
+# This variable must not be named VAULT_VERSION, as that conflicts with
+# vault's internal VAULT_VERSION variable communicated with plugins
+ENV VAULT_INSTALL_VERSION=1.1.0-beta2
 
 # Create a vault user and group first so the IDs get set the same way,
 # even as the rest of this may change over time.
@@ -32,12 +34,12 @@ RUN set -eux; \
     test -z "$found" && echo >&2 "error: failed to fetch GPG key $VAULT_GPGKEY" && exit 1; \
     mkdir -p /tmp/build && \
     cd /tmp/build && \
-    wget https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_${ARCH}.zip && \
-    wget https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_SHA256SUMS && \
-    wget https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_SHA256SUMS.sig && \
-    gpg --batch --verify vault_${VAULT_VERSION}_SHA256SUMS.sig vault_${VAULT_VERSION}_SHA256SUMS && \
-    grep vault_${VAULT_VERSION}_linux_${ARCH}.zip vault_${VAULT_VERSION}_SHA256SUMS | sha256sum -c && \
-    unzip -d /bin vault_${VAULT_VERSION}_linux_${ARCH}.zip && \
+    wget https://releases.hashicorp.com/vault/${VAULT_INSTALL_VERSION}/vault_${VAULT_INSTALL_VERSION}_linux_${ARCH}.zip && \
+    wget https://releases.hashicorp.com/vault/${VAULT_INSTALL_VERSION}/vault_${VAULT_INSTALL_VERSION}_SHA256SUMS && \
+    wget https://releases.hashicorp.com/vault/${VAULT_INSTALL_VERSION}/vault_${VAULT_INSTALL_VERSION}_SHA256SUMS.sig && \
+    gpg --batch --verify vault_${VAULT_INSTALL_VERSION}_SHA256SUMS.sig vault_${VAULT_INSTALL_VERSION}_SHA256SUMS && \
+    grep vault_${VAULT_INSTALL_VERSION}_linux_${ARCH}.zip vault_${VAULT_INSTALL_VERSION}_SHA256SUMS | sha256sum -c && \
+    unzip -d /bin vault_${VAULT_INSTALL_VERSION}_linux_${ARCH}.zip && \
     cd /tmp && \
     rm -rf /tmp/build && \
     gpgconf --kill dirmngr && \


### PR DESCRIPTION
Today I tried to get a custom database plugin running within the Vault docker container, only to face the error `net/rpc plugin protocol not supported`

After a bit of digging I found https://github.com/hashicorp/vault/blob/master/helper/pluginutil/env.go#L36 and tried changing the name of the `VAULT_VERSION` environment variable used within the `Dockerfile` to something else. This resolved my issue, so there appears to be an issue with vault plugins if the `VAULT_VERSION` environment variable is already set upon starting Vault.

My simple fix is to refrain from setting `VAULT_VERSION` in the container.

Instead of this PR it might be desired to fix the environment setting behavior in https://github.com/hashicorp/vault/blob/fb89af7cfa66b033951fa4c44ff31718537f094f/helper/pluginutil/runner.go#L81