### PR TITLE
Upgrade alpine to 3.9

### DIFF
--- a/0.X/Dockerfile
+++ b/0.X/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.9
 
 # This is the release of Vault to pull in.
 ARG VAULT_VERSION=1.1.3


### PR DESCRIPTION
Currently we're using Alpine 3.8 which is over a year old at this point.  This upgrades Alpine to 3.9 which is the same version the Consul images are using.  Tested swapping images with different versions and no issues occurred.

Alpine 3.10 just released, if there's interest in leap frogging to that version, let me know!