### PR TITLE
build: add Makefile with targets for enterprise build

### DIFF
--- a/0.X/Makefile
+++ b/0.X/Makefile
@@ -1,0 +1,17 @@
+REGISTRY_NAME?=docker.io/hashicorp
+IMAGE_NAME=vault-enterprise
+VERSION=1.2.3
+IMAGE_TAG=$(REGISTRY_NAME)/$(IMAGE_NAME):$(VERSION)
+
+.PHONY: build image publish
+
+build: image publish
+
+image: 
+	docker build --build-arg VAULT_VERSION=$(VERSION)+ent --no-cache -t $(IMAGE_TAG)_ent .
+	docker build --build-arg VAULT_VERSION=$(VERSION)+ent.hsm --no-cache -t $(IMAGE_TAG)_ent.hsm .
+
+
+publish: 
+	docker push $(IMAGE_TAG)_ent
+	docker push $(IMAGE_TAG)_ent.hsm


### PR DESCRIPTION
Targets for populating https://cloud.docker.com/u/hashicorp/repository/registry-1.docker.io/hashicorp/vault-enterprise