### PR TITLE
Listen on both IPv4 and IPv6 by default

### DIFF
--- a/0.X/docker-entrypoint.sh
+++ b/0.X/docker-entrypoint.sh
@@ -55,7 +55,7 @@ if [ "$1" = 'server' ]; then
     set -- vault server \
         -config="$VAULT_CONFIG_DIR" \
         -dev-root-token-id="$VAULT_DEV_ROOT_TOKEN_ID" \
-        -dev-listen-address="${VAULT_DEV_LISTEN_ADDRESS:-"0.0.0.0:8200"}" \
+        -dev-listen-address="${VAULT_DEV_LISTEN_ADDRESS:-":8200"}" \
         "$@"
 elif [ "$1" = 'version' ]; then
     # This needs a special case because there's no help output.


### PR DESCRIPTION
We use `-dev-listen-address` with 0.0.0.0 as default prefix.
This means that Vault listener factory [1] bind only on IPv4.

We would like to bind on both IPv4 and IPv6 by default.
net.Listen [1] creates servers which can be bind on both IPv4 and
IPv6 when we provide an empty host address such as ":8200".

[1] https://github.com/hashicorp/vault/blob/15863772554cbea9a75e1146a152cd9fb112bb0f/command/server/listener_tcp.go#L27
[1] https://golang.org/pkg/net/#Listen