### PR TITLE
Add UBI Docker images

### DIFF
--- a/ubi/Dockerfile
+++ b/ubi/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.2
 
 LABEL maintainer="HashiCorp"
-ARG VAULT_VERSION=1.5.3
+ARG VAULT_VERSION=1.5.4
  
 # Set up certificates, our base tools, and Vault.
 RUN set -eux; \

--- a/ubi/Dockerfile
+++ b/ubi/Dockerfile
@@ -1,0 +1,76 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.2
+
+LABEL maintainer="HashiCorp"
+ARG VAULT_VERSION=1.5.3
+ 
+# Set up certificates, our base tools, and Vault.
+RUN set -eux; \
+    microdnf install -y ca-certificates gnupg openssl libcap tzdata wget unzip procps shadow-utils util-linux && \
+    VAULT_GPGKEY=91A6E7F85D05C65630BEF18951852D87348FFC4C; \
+    found=''; \
+    for server in \
+        hkp://p80.pool.sks-keyservers.net:80 \
+        hkp://keyserver.ubuntu.com:80 \
+        hkp://pgp.mit.edu:80 \
+    ; do \
+        echo "Fetching GPG key $VAULT_GPGKEY from $server"; \
+        gpg --batch --keyserver "$server" --recv-keys "$VAULT_GPGKEY" && found=yes && break; \
+    done; \
+    test -z "$found" && echo >&2 "error: failed to fetch GPG key $VAULT_GPGKEY" && exit 1; \
+    mkdir -p /tmp/build && \
+    cd /tmp/build && \
+    wget https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip && \
+    wget https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_SHA256SUMS && \
+    wget https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_SHA256SUMS.sig && \
+    gpg --batch --verify vault_${VAULT_VERSION}_SHA256SUMS.sig vault_${VAULT_VERSION}_SHA256SUMS && \
+    grep vault_${VAULT_VERSION}_linux_amd64.zip vault_${VAULT_VERSION}_SHA256SUMS | sha256sum -c && \
+    unzip -d /bin vault_${VAULT_VERSION}_linux_amd64.zip && \
+    cd /tmp && \
+    rm -rf /tmp/build && \
+    gpgconf --kill dirmngr && \
+    gpgconf --kill gpg-agent && \
+    rm -rf /root/.gnupg
+
+RUN groupadd --gid 1000 vault && \
+    adduser --uid 100 --system -g vault vault && \
+    usermod -a -G root vault
+
+# /vault/logs is made available to use as a location to store audit logs, if
+# desired; /vault/file is made available to use as a location with the file
+# storage backend, if desired; the server will be started with /vault/config as
+# the configuration directory so you can add additional config files in that
+# location.
+ENV HOME /home/vault
+RUN mkdir -p /vault/logs && \
+    mkdir -p /vault/file && \
+    mkdir -p /vault/config && \
+    mkdir -p $HOME && \
+    chown -R vault /vault && chown -R vault $HOME && \ 
+    chgrp -R 0 $HOME && chmod -R g+rwX $HOME && \
+    chgrp -R 0 /vault && chmod -R g+rwX /vault
+
+# Expose the logs directory as a volume since there's potentially long-running
+# state in there
+VOLUME /vault/logs
+
+# Expose the file directory as a volume since there's potentially long-running
+# state in there
+VOLUME /vault/file
+
+# 8200/tcp is the primary interface that applications use to interact with
+# Vault.
+EXPOSE 8200
+
+# The entry point script uses dumb-init as the top-level process to reap any
+# zombie processes created by Vault sub-processes.
+#
+# For production derivatives of this container, you shoud add the IPC_LOCK
+# capability so that Vault can mlock memory.
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+USER 100
+
+# By default you'll get a single-node development server that stores everything
+# in RAM and bootstraps itself. Don't use this configuration for production.
+CMD ["server", "-dev"]

--- a/ubi/Dockerfile
+++ b/ubi/Dockerfile
@@ -61,11 +61,6 @@ VOLUME /vault/file
 # Vault.
 EXPOSE 8200
 
-# The entry point script uses dumb-init as the top-level process to reap any
-# zombie processes created by Vault sub-processes.
-#
-# For production derivatives of this container, you shoud add the IPC_LOCK
-# capability so that Vault can mlock memory.
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 ENTRYPOINT ["docker-entrypoint.sh"]
 

--- a/ubi/Makefile
+++ b/ubi/Makefile
@@ -1,7 +1,7 @@
 REGISTRY_NAME?=docker.io/hashicorp
-VERSION=1.5.4
-IMAGE_TAG_ENT=$(REGISTRY_NAME)/vault-enterprise:$(VERSION)_ent
-IMAGE_TAG_OSS=$(REGISTRY_NAME)/vault:$(VERSION)
+VERSION=1.5.3
+IMAGE_TAG_ENT=$(REGISTRY_NAME)/vault-enterprise:$(VERSION)_ubi_ent
+IMAGE_TAG_OSS=$(REGISTRY_NAME)/vault:$(VERSION)_ubi
 
 .PHONY: build ent-image oss-image
 

--- a/ubi/Makefile
+++ b/ubi/Makefile
@@ -1,5 +1,5 @@
 REGISTRY_NAME?=docker.io/hashicorp
-VERSION=1.5.3
+VERSION=1.5.4
 IMAGE_TAG_ENT=$(REGISTRY_NAME)/vault-enterprise:$(VERSION)_ubi_ent
 IMAGE_TAG_OSS=$(REGISTRY_NAME)/vault:$(VERSION)_ubi
 

--- a/ubi/README.md
+++ b/ubi/README.md
@@ -1,0 +1,11 @@
+# Vault Official UBI Image Build
+
+The UBI version of this hosted on [HashiCorp's Docker Hub for Vault](https://hub.docker.com/r/hashicorp/vault/).
+
+There are several pieces that are used to build this image:
+
+* We start with an UBI base image and add CA certificates in order to reach
+  the HashiCorp releases server. These are useful to leave in the image so that
+  the container can access Atlas features as well.
+* Finally a specific Vault build is fetched and the rest of the Vault-specific
+  configuration happens according to the Dockerfile.

--- a/ubi/docker-entrypoint.sh
+++ b/ubi/docker-entrypoint.sh
@@ -1,0 +1,108 @@
+#!/bin/sh
+set -e
+
+# Prevent core dumps
+ulimit -c 0
+
+# Allow setting VAULT_REDIRECT_ADDR and VAULT_CLUSTER_ADDR using an interface
+# name instead of an IP address. The interface name is specified using
+# VAULT_REDIRECT_INTERFACE and VAULT_CLUSTER_INTERFACE environment variables. If
+# VAULT_*_ADDR is also set, the resulting URI will combine the protocol and port
+# number with the IP of the named interface.
+get_addr () {
+    local if_name=$1
+    local uri_template=$2
+    ip addr show dev $if_name | awk -v uri=$uri_template '/\s*inet\s/ { \
+      ip=gensub(/(.+)\/.+/, "\\1", "g", $2); \
+      print gensub(/^(.+:\/\/).+(:.+)$/, "\\1" ip "\\2", "g", uri); \
+      exit}'
+}
+
+if [ -n "$VAULT_REDIRECT_INTERFACE" ]; then
+    export VAULT_REDIRECT_ADDR=$(get_addr $VAULT_REDIRECT_INTERFACE ${VAULT_REDIRECT_ADDR:-"http://0.0.0.0:8200"})
+    echo "Using $VAULT_REDIRECT_INTERFACE for VAULT_REDIRECT_ADDR: $VAULT_REDIRECT_ADDR"
+fi
+if [ -n "$VAULT_CLUSTER_INTERFACE" ]; then
+    export VAULT_CLUSTER_ADDR=$(get_addr $VAULT_CLUSTER_INTERFACE ${VAULT_CLUSTER_ADDR:-"https://0.0.0.0:8201"})
+    echo "Using $VAULT_CLUSTER_INTERFACE for VAULT_CLUSTER_ADDR: $VAULT_CLUSTER_ADDR"
+fi
+
+# VAULT_CONFIG_DIR isn't exposed as a volume but you can compose additional
+# config files in there if you use this image as a base, or use
+# VAULT_LOCAL_CONFIG below.
+VAULT_CONFIG_DIR=/vault/config
+
+# You can also set the VAULT_LOCAL_CONFIG environment variable to pass some
+# Vault configuration JSON without having to bind any volumes.
+if [ -n "$VAULT_LOCAL_CONFIG" ]; then
+    echo "$VAULT_LOCAL_CONFIG" > "$VAULT_CONFIG_DIR/local.json"
+fi
+
+# If the user is trying to run Vault directly with some arguments, then
+# pass them to Vault.
+if [ "${1:0:1}" = '-' ]; then
+    set -- vault "$@"
+fi
+
+# Look for Vault subcommands.
+if [ "$1" = 'server' ]; then
+    shift
+    set -- vault server \
+        -config="$VAULT_CONFIG_DIR" \
+        -dev-root-token-id="$VAULT_DEV_ROOT_TOKEN_ID" \
+        -dev-listen-address="${VAULT_DEV_LISTEN_ADDRESS:-"0.0.0.0:8200"}" \
+        "$@"
+elif [ "$1" = 'version' ]; then
+    # This needs a special case because there's no help output.
+    set -- vault "$@"
+elif vault --help "$1" 2>&1 | grep -q "vault $1"; then
+    # We can't use the return code to check for the existence of a subcommand, so
+    # we have to use grep to look for a pattern in the help output.
+    set -- vault "$@"
+fi
+
+# If we are running Vault, make sure it executes as the proper user.
+if [ "$1" = 'vault' ]; then
+    if [ -z "$SKIP_CHOWN" ]; then
+        # If the config dir is bind mounted then chown it
+        if [ "$(stat -c %u /vault/config)" != "$(id -u vault)" ]; then
+            chown -R vault:vault /vault/config || echo "Could not chown /vault/config (may not have appropriate permissions)"
+        fi
+
+        # If the logs dir is bind mounted then chown it
+        if [ "$(stat -c %u /vault/logs)" != "$(id -u vault)" ]; then
+            chown -R vault:vault /vault/logs
+        fi
+
+        # If the file dir is bind mounted then chown it
+        if [ "$(stat -c %u /vault/file)" != "$(id -u vault)" ]; then
+            chown -R vault:vault /vault/file
+        fi
+    fi
+
+    if [ -z "$SKIP_SETCAP" ]; then
+        # Allow mlock to avoid swapping Vault memory to disk
+        setcap cap_ipc_lock=+ep $(readlink -f /bin/vault)
+
+        # In the case vault has been started in a container without IPC_LOCK privileges
+        if ! vault -version 1>/dev/null 2>/dev/null; then
+            >&2 echo "Couldn't start vault with IPC_LOCK. Disabling IPC_LOCK, please use --privileged or --cap-add IPC_LOCK"
+            setcap cap_ipc_lock=-ep $(readlink -f /bin/vault)
+        fi
+    fi
+fi
+
+# In case of Docker, where swap may be enabled, we 
+# still require mlocking to be available. So this script 
+# was executed as root to make this happen, however, 
+# we're now rerunning the entrypoint script as the Vault 
+# user but no longer need to run setup code for setcap
+# or chowning directories (previously done on the first run).
+if [[ "$(id -u)" == '0' ]]
+then
+    export SKIP_CHOWN="true"
+    export SKIP_SETCAP="true"
+    exec su vault -p "$0" -- "$@"
+else
+    exec "$@" 
+fi


### PR DESCRIPTION
This adds support for UBI flavored container images. All UBI related files are in a new directory `ubi/` in the root directory of this project.

UBI-minimal is being used as the base image to shave a little bit off the container image size.