### PR TITLE
chore: Vault 1.5.5

### DIFF
--- a/0.X/Dockerfile
+++ b/0.X/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.10
 
 # This is the release of Vault to pull in.
-ARG VAULT_VERSION=1.5.4
+ARG VAULT_VERSION=1.5.5
 
 # Create a vault user and group first so the IDs get set the same way,
 # even as the rest of this may change over time.

--- a/0.X/Makefile
+++ b/0.X/Makefile
@@ -1,5 +1,5 @@
 REGISTRY_NAME?=docker.io/hashicorp
-VERSION=1.5.4
+VERSION=1.5.5
 IMAGE_TAG_ENT=$(REGISTRY_NAME)/vault-enterprise:$(VERSION)_ent
 IMAGE_TAG_OSS=$(REGISTRY_NAME)/vault:$(VERSION)
 
@@ -7,7 +7,7 @@ IMAGE_TAG_OSS=$(REGISTRY_NAME)/vault:$(VERSION)
 
 build: ent-image oss-image
 
-ent-image: 
+ent-image:
 	docker build --build-arg VAULT_VERSION=$(VERSION)+ent --no-cache -t $(IMAGE_TAG_ENT) .
 	docker tag $(IMAGE_TAG_ENT) $(REGISTRY_NAME)/vault-enterprise:latest
 


### PR DESCRIPTION
```console
$ docker run --rm --cap-add IPC_LOCK hashicorp/vault --version
Vault v1.5.5 (f5d1ddb3750e7c28e25036e1ef26a4c02379fc01)
```