### PR TITLE
upgrade packages with CVEs

### DIFF
--- a/0.X/Dockerfile
+++ b/0.X/Dockerfile
@@ -5,7 +5,9 @@ ARG VAULT_VERSION=1.6.2
 
 # Create a vault user and group first so the IDs get set the same way,
 # even as the rest of this may change over time.
-RUN addgroup vault && \
+RUN apk update && \
+    apk --no-cache upgrade && \
+    addgroup vault && \
     adduser -S -G vault vault
 
 # Set up certificates, our base tools, and Vault.


### PR DESCRIPTION
Upgrade all packages to avoid out-dated packages. 
The packages 'libcrypto' 1.1.1g-r0, 'libssl' 1.1.1g-r0 and 'musl-utils' 1.1.22-r3 are reported has having CVE-2020-1971 and CVE-2020-28928.