### PR TITLE
use keys.openpgp.org as the first keyserver entry

### DIFF
--- a/0.X/Dockerfile
+++ b/0.X/Dockerfile
@@ -22,6 +22,7 @@ RUN set -eux; \
     VAULT_GPGKEY=91A6E7F85D05C65630BEF18951852D87348FFC4C; \
     found=''; \
     for server in \
+        hkps://keys.openpgp.org \
         hkp://p80.pool.sks-keyservers.net:80 \
         hkp://keyserver.ubuntu.com:80 \
         hkp://pgp.mit.edu:80 \


### PR DESCRIPTION
Use the keys.openpgp.org as the first keyserver entry.
Use this keyserver as default is an advisable change after the certificate spamming attack against two high-profile contributors in 2019. 
https://gist.github.com/rjhansen/67ab921ffb4084c865b3618d6955275f

The keys.openpgp.org is used by default in GPGTools, Enigmail, OpenKeychain, GPGSync, Debian, and NixOS.