### PR TITLE
Update UBI to 1.6.2

### DIFF
--- a/ubi/Dockerfile
+++ b/ubi/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.2
 
 LABEL maintainer="HashiCorp"
-ARG VAULT_VERSION=1.5.5
+ARG VAULT_VERSION=1.6.2
 
 # Additional metadata labels used by container registries, platforms
 # and certification scanners.

--- a/ubi/Makefile
+++ b/ubi/Makefile
@@ -1,5 +1,5 @@
 REGISTRY_NAME?=docker.io/hashicorp
-VERSION=1.5.5
+VERSION=1.6.2
 IMAGE_TAG_ENT=$(REGISTRY_NAME)/vault-enterprise:$(VERSION)-ubi-ent
 IMAGE_TAG_OSS=$(REGISTRY_NAME)/vault:$(VERSION)-ubi
 


### PR DESCRIPTION
UBI images aren't being updated per each Vault release, so pushing to the latest version externally.