### PR TITLE
Upgrade alpine to 3.13

### DIFF
--- a/0.X/Dockerfile
+++ b/0.X/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM alpine:3.13
 
 # This is the release of Vault to pull in.
 ARG VAULT_VERSION=1.6.2


### PR DESCRIPTION
The docker-vault image uses alpine:3.10 since Jul 9, 2019.
An upgrade is advisable since the packages 'libcrypto' 1.1.1g-r0, 'libssl' 1.1.1g-r0, and 'musl-utils' 1.1.22-r3 have CVE-2020-1971 and CVE-2020-28928 reported. 
Aqua trivy and Prisma Cloud twistcli both reports these issues.