### PR TITLE
RELENG-86 fixing to only push the latest tag if its not a prerelease

### DIFF
--- a/0.X/Makefile
+++ b/0.X/Makefile
@@ -14,3 +14,6 @@ ent-image:
 oss-image:
 	docker build --build-arg VAULT_VERSION=$(VERSION) --no-cache -t $(IMAGE_TAG_OSS) .
 	docker tag $(IMAGE_TAG_OSS) $(REGISTRY_NAME)/vault:latest
+
+ci.docker-stage: 
+	@./0.X/tag-images.sh

--- a/0.X/Makefile
+++ b/0.X/Makefile
@@ -1,5 +1,5 @@
 REGISTRY_NAME?=docker.io/hashicorp
-VERSION=1.7.0
+export VERSION=1.7.0
 IMAGE_TAG_ENT=$(REGISTRY_NAME)/vault-enterprise:$(VERSION)_ent
 IMAGE_TAG_OSS=$(REGISTRY_NAME)/vault:$(VERSION)
 
@@ -9,11 +9,9 @@ build: ent-image oss-image
 
 ent-image: 
 	docker build --build-arg VAULT_VERSION=$(VERSION)+ent --no-cache -t $(IMAGE_TAG_ENT) .
-	docker tag $(IMAGE_TAG_ENT) $(REGISTRY_NAME)/vault-enterprise:latest
+	@./tag-images.sh
 
 oss-image:
 	docker build --build-arg VAULT_VERSION=$(VERSION) --no-cache -t $(IMAGE_TAG_OSS) .
-	docker tag $(IMAGE_TAG_OSS) $(REGISTRY_NAME)/vault:latest
+	@./tag-images.sh
 
-ci.docker-stage: 
-	@./0.X/tag-images.sh

--- a/0.X/Makefile
+++ b/0.X/Makefile
@@ -5,7 +5,7 @@ export VERSION=1.7.0-rc1
 
 build: ent-image oss-image
 
-ent-imgage: export PROJECT_NAME=vault-enterprise
+ent-image: export PROJECT_NAME=vault-enterprise
 ent-image: export TAG_SUFFIX=_ent
 ent-image: 
 	docker build --label version=$(VERSION) --build-arg VAULT_VERSION=$(VERSION)+ent --no-cache -t $(REGISTRY_NAME)/$(PROJECT_NAME):$(VERSION)$(TAG_SUFFIX) .

--- a/0.X/Makefile
+++ b/0.X/Makefile
@@ -1,17 +1,17 @@
-REGISTRY_NAME?=docker.io/hashicorp
-export VERSION=1.7.0
-IMAGE_TAG_ENT=$(REGISTRY_NAME)/vault-enterprise:$(VERSION)_ent
-IMAGE_TAG_OSS=$(REGISTRY_NAME)/vault:$(VERSION)
+export REGISTRY_NAME?=docker.io/hashicorp
+export VERSION=1.7.0-rc1
 
 .PHONY: build ent-image oss-image
 
 build: ent-image oss-image
 
+ent-imgage: export PROJECT_NAME=vault-enterprise
+ent-image: export TAG_SUFFIX=_ent
 ent-image: 
-	docker build --build-arg VAULT_VERSION=$(VERSION)+ent --no-cache -t $(IMAGE_TAG_ENT) .
-	@./tag-images.sh
+	docker build --label version=$(VERSION) --build-arg VAULT_VERSION=$(VERSION)+ent --no-cache -t $(REGISTRY_NAME)/$(PROJECT_NAME):$(VERSION)$(TAG_SUFFIX) .
+	@../scripts/tag-images.sh
 
 oss-image:
-	docker build --build-arg VAULT_VERSION=$(VERSION) --no-cache -t $(IMAGE_TAG_OSS) .
-	@./tag-images.sh
+	docker build --label version=$(VERSION) --build-arg VAULT_VERSION=$(VERSION) --no-cache -t $(REGISTRY_NAME)/$(PROJECT_NAME):$(VERSION) .
+	@../scripts/tag-images.sh
 

--- a/0.X/Makefile
+++ b/0.X/Makefile
@@ -1,5 +1,5 @@
 export REGISTRY_NAME?=docker.io/hashicorp
-export VERSION=1.7.0-rc1
+export VERSION=1.7.0
 
 .PHONY: build ent-image oss-image
 

--- a/0.X/tag-images.sh
+++ b/0.X/tag-images.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# If this is not a pre-release, we determine if any of the 'latest' images need to be updated
+
+function main() {
+   
+   if [[ "${DOCKER_TAG}" =~ [0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+      # check to see if the current tag is higher than the latest version on dockerhub
+      HIGHER_LATEST_VERSION=$(higher_version "$DOCKER_TAG" "$LATEST_DOCKER_VERSION")
+      echo "Docker tag is: $DOCKER_TAG"
+      echo "Latest tag is: $LATEST_DOCKER_VERSION"
+      echo "Higher version is: $HIGHER_LATEST_VERSION"
+      # if:
+      #   * we didn't find a version from the 'latest' image, it means it doesn't exist
+      #   * or if the current tag version is higher than the latest docker one (or the same)
+      # we build latest
+      if [ -z "$LATEST_DOCKER_VERSION" ] || [ "$HIGHER_LATEST_VERSION" = "$DOCKER_TAG" ]; then
+         echo "Tagging a new latest docker image"
+         docker tag "$DOCKER_ORG"/"$PROJECT_NAME":"$DOCKER_TAG" "$DOCKER_ORG"/"$PROJECT_NAME":latest || return 1
+         docker push "$DOCKER_ORG"/"$PROJECT_NAME":latest || return 1
+      fi
+   fi
+   # If it is a prerelease, we don't tag latest so we do nothing here
+
+   return 0
+}
+main "$@"
+exit $?

--- a/scripts/tag-images.sh
+++ b/scripts/tag-images.sh
@@ -47,25 +47,11 @@ function main() {
 
 	: "${PROJECT_NAME?"Need to set PROJECT_NAME"}"
 
-	# LATEST_DOCKER_VERSION=$(get_latest_docker_version "$REGISTRY_NAME" "$PROJECT_NAME") || return 1
-	# echo "latest docker version is: $LATEST_DOCKER_VERSION"
-
 	DOCKER_TAG="$VERSION$TAG_SUFFIX"
 
    if [[ "${VERSION}" =~ [0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-      # check to see if the current tag is higher than the latest version on dockerhub
-    #   HIGHER_LATEST_VERSION=$(higher_version "$VERSION" "$LATEST_DOCKER_VERSION")
-    #   echo "Image version is: $VERSION"
-    #   echo "Latest tag is: $LATEST_DOCKER_VERSION"
-    #   echo "Higher version is: $HIGHER_LATEST_VERSION"
-      # if:
-      #   * we didn't find a version from the 'latest' image, it means it doesn't exist
-      #   * or if the current tag version is higher than the latest docker one (or the same)
-      # we build latest
-    #   if [ -z "$LATEST_DOCKER_VERSION" ] || [ "$HIGHER_LATEST_VERSION" = "$VERSION" ]; then
          echo "Tagging a new latest docker image"
          docker tag "$REGISTRY_NAME"/"$PROJECT_NAME":"$DOCKER_TAG" "$REGISTRY_NAME"/"$PROJECT_NAME":latest || return 1
-    #   fi
    fi
    # If it is a prerelease, we don't tag latest so we do nothing here
 

--- a/scripts/tag-images.sh
+++ b/scripts/tag-images.sh
@@ -15,7 +15,7 @@ function get_latest_docker_version {
    #   0 - success (version in the 'latest' container echoed)
    #   1 - 'latest' tag does not exist or label could not be found
 
-   docker pull "$1"/"$2":latest 
+   docker pull "$1"/"$2":latest
    local docker_latest=$(docker inspect --format="{{ index .Config.Labels.version }}" "$1"/"$2":latest)
    if [ -z "$docker_latest" ]; then
       return 1
@@ -41,31 +41,31 @@ function higher_version {
 # If this is not a pre-release, we determine if any of the 'latest' images need to be updated
 function main() {
 
-      : "${VERSION?"Need to set VERSION"}"
-      
-      : "${REGISTRY_NAME?"Need to set REGISTRY_NAME"}"
-      
-      : "${PROJECT_NAME?"Need to set PROJECT_NAME"}
+	: "${VERSION?"Need to set VERSION"}"
 
-   #  LATEST_DOCKER_VERSION=$(get_latest_docker_version "$DOCKER_ORG" "$PROJECT_NAME")
-      # echo "latest docker version is: $LATEST_DOCKER_VERSION"
+	: "${REGISTRY_NAME?"Need to set REGISTRY_NAME"}"
 
-    DOCKER_TAG="$VERSION$TAG_SUFFIX"
-   
+	: "${PROJECT_NAME?"Need to set PROJECT_NAME"}"
+
+	# LATEST_DOCKER_VERSION=$(get_latest_docker_version "$REGISTRY_NAME" "$PROJECT_NAME") || return 1
+	# echo "latest docker version is: $LATEST_DOCKER_VERSION"
+
+	DOCKER_TAG="$VERSION$TAG_SUFFIX"
+
    if [[ "${VERSION}" =~ [0-9]+\.[0-9]+\.[0-9]+$ ]]; then
       # check to see if the current tag is higher than the latest version on dockerhub
-      #  HIGHER_LATEST_VERSION=$(higher_version "$DOCKER_TAG" "$LATEST_DOCKER_VERSION")
-      #  echo "Docker tag is: $DOCKER_TAG"
-      #  echo "Latest tag is: $LATEST_DOCKER_VERSION"
-      #  echo "Higher version is: $HIGHER_LATEST_VERSION"
+    #   HIGHER_LATEST_VERSION=$(higher_version "$VERSION" "$LATEST_DOCKER_VERSION")
+    #   echo "Image version is: $VERSION"
+    #   echo "Latest tag is: $LATEST_DOCKER_VERSION"
+    #   echo "Higher version is: $HIGHER_LATEST_VERSION"
       # if:
       #   * we didn't find a version from the 'latest' image, it means it doesn't exist
       #   * or if the current tag version is higher than the latest docker one (or the same)
       # we build latest
-      # if [ -z "$LATEST_DOCKER_VERSION" ] || [ "$HIGHER_LATEST_VERSION" = "$VERSION" ]; then
+    #   if [ -z "$LATEST_DOCKER_VERSION" ] || [ "$HIGHER_LATEST_VERSION" = "$VERSION" ]; then
          echo "Tagging a new latest docker image"
          docker tag "$REGISTRY_NAME"/"$PROJECT_NAME":"$DOCKER_TAG" "$REGISTRY_NAME"/"$PROJECT_NAME":latest || return 1
-      # fi
+    #   fi
    fi
    # If it is a prerelease, we don't tag latest so we do nothing here
 

--- a/scripts/tag-images.sh
+++ b/scripts/tag-images.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-#     * PRERELEASE_VERSION - any prerelease versions (beta1, rc1)
+#    * VERSION - Image version to tag i.e 1.7.0 or 1.7.0-
+#	  * REGISTRY_NAME - Docker Registry Name i.e docker.io/hashicorp
+#	  * PROJECT_NAME - Project name i.e vault or vault-enterprise
 
 # Introspects the docker label of an container to see what version 'latest' is
 function get_latest_docker_version {
@@ -13,9 +15,8 @@ function get_latest_docker_version {
    #   0 - success (version in the 'latest' container echoed)
    #   1 - 'latest' tag does not exist or label could not be found
 
-   docker pull "$1"/"$2":latest &> /dev/null
-   local docker_latest=$(docker inspect --format="{{ index .Config.Labels.version }}" "$1"/"$2":latest 2> /dev/null)
-
+   docker pull "$1"/"$2":latest 
+   local docker_latest=$(docker inspect --format="{{ index .Config.Labels.version }}" "$1"/"$2":latest)
    if [ -z "$docker_latest" ]; then
       return 1
    else
@@ -40,29 +41,31 @@ function higher_version {
 # If this is not a pre-release, we determine if any of the 'latest' images need to be updated
 function main() {
 
-   : "${VERSION?"Need to set VERSION"}"
+      : "${VERSION?"Need to set VERSION"}"
+      
+      : "${REGISTRY_NAME?"Need to set REGISTRY_NAME"}"
+      
+      : "${PROJECT_NAME?"Need to set PROJECT_NAME"}
 
-   DOCKER_ORG=${DOCKER_ORG:="hashicorp"}
+   #  LATEST_DOCKER_VERSION=$(get_latest_docker_version "$DOCKER_ORG" "$PROJECT_NAME")
+      # echo "latest docker version is: $LATEST_DOCKER_VERSION"
 
-   LATEST_DOCKER_VERSION=$(get_latest_docker_version "$DOCKER_ORG" "$PROJECT_NAME")
-    echo "latest docker version is: $LATEST_DOCKER_VERSION"
-
-    DOCKER_TAG=${VERSION:?"VERSION is not set"}
+    DOCKER_TAG="$VERSION$TAG_SUFFIX"
    
-   if [[ "${DOCKER_TAG}" =~ [0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+   if [[ "${VERSION}" =~ [0-9]+\.[0-9]+\.[0-9]+$ ]]; then
       # check to see if the current tag is higher than the latest version on dockerhub
-      HIGHER_LATEST_VERSION=$(higher_version "$DOCKER_TAG" "$LATEST_DOCKER_VERSION")
-      echo "Docker tag is: $DOCKER_TAG"
-      echo "Latest tag is: $LATEST_DOCKER_VERSION"
-      echo "Higher version is: $HIGHER_LATEST_VERSION"
+      #  HIGHER_LATEST_VERSION=$(higher_version "$DOCKER_TAG" "$LATEST_DOCKER_VERSION")
+      #  echo "Docker tag is: $DOCKER_TAG"
+      #  echo "Latest tag is: $LATEST_DOCKER_VERSION"
+      #  echo "Higher version is: $HIGHER_LATEST_VERSION"
       # if:
       #   * we didn't find a version from the 'latest' image, it means it doesn't exist
       #   * or if the current tag version is higher than the latest docker one (or the same)
       # we build latest
-      if [ -z "$LATEST_DOCKER_VERSION" ] || [ "$HIGHER_LATEST_VERSION" = "$DOCKER_TAG" ]; then
+      # if [ -z "$LATEST_DOCKER_VERSION" ] || [ "$HIGHER_LATEST_VERSION" = "$VERSION" ]; then
          echo "Tagging a new latest docker image"
-         docker tag "$DOCKER_ORG"/"$PROJECT_NAME":"$DOCKER_TAG" "$DOCKER_ORG"/"$PROJECT_NAME":latest || return 1
-      fi
+         docker tag "$REGISTRY_NAME"/"$PROJECT_NAME":"$DOCKER_TAG" "$REGISTRY_NAME"/"$PROJECT_NAME":latest || return 1
+      # fi
    fi
    # If it is a prerelease, we don't tag latest so we do nothing here
 

--- a/ubi/Makefile
+++ b/ubi/Makefile
@@ -1,16 +1,20 @@
-REGISTRY_NAME?=docker.io/hashicorp
-VERSION=1.7.0
-IMAGE_TAG_ENT=$(REGISTRY_NAME)/vault-enterprise:$(VERSION)-ubi-ent
-IMAGE_TAG_OSS=$(REGISTRY_NAME)/vault:$(VERSION)-ubi
+export REGISTRY_NAME?=docker.io/hashicorp
+export VERSION=1.7.0
 
 .PHONY: build ent-image oss-image
 
 build: ent-image oss-image
 
+ent-image: export PROJECT_NAME=vault-enterprise
+ent-image: export TAG_SUFFIX=-ubi-ent
 ent-image:
-	docker build --build-arg VAULT_VERSION=$(VERSION)+ent --no-cache -t $(IMAGE_TAG_ENT) .
+	docker build --label version=$(VERSION) --build-arg VAULT_VERSION=$(VERSION)+ent --no-cache -t $(REGISTRY_NAME)/$(PROJECT_NAME):$(VERSION)$(TAG_SUFFIX) .
 	docker tag $(IMAGE_TAG_ENT) $(REGISTRY_NAME)/vault-enterprise:latest
+	@../scripts/tag-images.sh
 
+oss-image: export PROJECT_NAME=vault
+oss-image: export TAG_SUFFIX=-ubi
 oss-image:
-	docker build --build-arg VAULT_VERSION=$(VERSION) --no-cache -t $(IMAGE_TAG_OSS) .
+	docker build --label version=$(VERSION) --build-arg VAULT_VERSION=$(VERSION) --no-cache -t $(REGISTRY_NAME)/$(PROJECT_NAME):$(VERSION)$(TAG_SUFFIX) .
 	docker tag $(IMAGE_TAG_OSS) $(REGISTRY_NAME)/vault:latest
+	@../scripts/tag-images.sh 


### PR DESCRIPTION
this is an update to change the docker-vault image to allow to only push the latest tag if its _not_ a pre-release.

hashicorp/docker-vault-publish#5 and #221 will need to be merged at the same time. 