### PR TITLE
Update HashiCorp GPG signing key

### DIFF
--- a/0.X/Dockerfile
+++ b/0.X/Dockerfile
@@ -19,7 +19,7 @@ RUN set -eux; \
         x86) ARCH='386' ;; \
         *) echo >&2 "error: unsupported architecture: $apkArch"; exit 1 ;; \
     esac && \
-    VAULT_GPGKEY=91A6E7F85D05C65630BEF18951852D87348FFC4C; \
+    VAULT_GPGKEY=C874011F0AB405110D02105534365D9472D7468F; \
     found=''; \
     for server in \
         hkp://p80.pool.sks-keyservers.net:80 \


### PR DESCRIPTION
HashiCorp's GPG signing key has been rotated as per [HCSEC-2021-12](https://discuss.hashicorp.com/t/hcsec-2021-12-codecov-security-event-and-hashicorp-gpg-key-exposure/23512). This PR updates the GPG signing key signature to the new one.

Fixes #224 