### PR TITLE
Update UBI base to 8.3

### DIFF
--- a/ubi/Dockerfile
+++ b/ubi/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.2
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3
 
 LABEL maintainer="HashiCorp"
 ARG VAULT_VERSION=1.7.2


### PR DESCRIPTION
Upgrading UBI base image to the latest to pass scanners.