### PR TITLE
Upgrade UBI to 8.4

### DIFF
--- a/ubi/Dockerfile
+++ b/ubi/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
 
 LABEL maintainer="HashiCorp"
 ARG VAULT_VERSION=1.8.0-rc2


### PR DESCRIPTION
UBI 8.3 fails Red Hat scanners and needs to be updated to 8.4. This has been tested and has caused no issues with the Vault image.