### PR TITLE
Remove --privileged recommendation from entrypoint script message

### DIFF
--- a/0.X/docker-entrypoint.sh
+++ b/0.X/docker-entrypoint.sh
@@ -91,7 +91,7 @@ if [ "$1" = 'vault' ]; then
 
         # In the case vault has been started in a container without IPC_LOCK privileges
         if ! vault -version 1>/dev/null 2>/dev/null; then
-            >&2 echo "Couldn't start vault with IPC_LOCK. Disabling IPC_LOCK, please use --privileged or --cap-add IPC_LOCK"
+            >&2 echo "Couldn't start vault with IPC_LOCK. Disabling IPC_LOCK, please use --cap-add IPC_LOCK"
             setcap cap_ipc_lock=-ep $(readlink -f $(which vault))
         fi
     fi

--- a/ubi/docker-entrypoint.sh
+++ b/ubi/docker-entrypoint.sh
@@ -86,7 +86,7 @@ if [ "$1" = 'vault' ]; then
 
         # In the case vault has been started in a container without IPC_LOCK privileges
         if ! vault -version 1>/dev/null 2>/dev/null; then
-            >&2 echo "Couldn't start vault with IPC_LOCK. Disabling IPC_LOCK, please use --privileged or --cap-add IPC_LOCK"
+            >&2 echo "Couldn't start vault with IPC_LOCK. Disabling IPC_LOCK, please use --cap-add IPC_LOCK"
             setcap cap_ipc_lock=-ep $(readlink -f /bin/vault)
         fi
     fi


### PR DESCRIPTION
The use of the `--privileged` [flag](https://docs.docker.com/engine/reference/commandline/run/#options) is not recommended, as it does not adhere to the principle of least privilege.