### PR TITLE
Update PGP key servers

### DIFF
--- a/0.X/Dockerfile
+++ b/0.X/Dockerfile
@@ -24,7 +24,7 @@ RUN set -eux; \
     for server in \
         hkps://keys.openpgp.org \
         hkps://keyserver.ubuntu.com \
-        hkp://pgp.mit.edu:80 \
+        hkps://pgp.mit.edu \
     ; do \
         echo "Fetching GPG key $VAULT_GPGKEY from $server"; \
         gpg --batch --keyserver "$server" --recv-keys "$VAULT_GPGKEY" && found=yes && break; \

--- a/0.X/Dockerfile
+++ b/0.X/Dockerfile
@@ -22,8 +22,8 @@ RUN set -eux; \
     VAULT_GPGKEY=C874011F0AB405110D02105534365D9472D7468F; \
     found=''; \
     for server in \
-        hkp://p80.pool.sks-keyservers.net:80 \
-        hkp://keyserver.ubuntu.com:80 \
+        hkps://keys.openpgp.org \
+        hkps://keyserver.ubuntu.com \
         hkp://pgp.mit.edu:80 \
     ; do \
         echo "Fetching GPG key $VAULT_GPGKEY from $server"; \

--- a/ubi/Dockerfile
+++ b/ubi/Dockerfile
@@ -24,7 +24,7 @@ RUN set -eux; \
     for server in \
         hkps://keys.openpgp.org \
         hkps://keyserver.ubuntu.com \
-        hkp://pgp.mit.edu:80 \
+        hkps://pgp.mit.edu \
     ; do \
         echo "Fetching GPG key $VAULT_GPGKEY from $server"; \
         gpg --batch --keyserver "$server" --recv-keys "$VAULT_GPGKEY" && found=yes && break; \

--- a/ubi/Dockerfile
+++ b/ubi/Dockerfile
@@ -22,8 +22,8 @@ RUN set -eux; \
     VAULT_GPGKEY=C874011F0AB405110D02105534365D9472D7468F; \
     found=''; \
     for server in \
-        hkp://p80.pool.sks-keyservers.net:80 \
-        hkp://keyserver.ubuntu.com:80 \
+        hkps://keys.openpgp.org \
+        hkps://keyserver.ubuntu.com \
         hkp://pgp.mit.edu:80 \
     ; do \
         echo "Fetching GPG key $VAULT_GPGKEY from $server"; \


### PR DESCRIPTION
Use hkps://keys.openpgp.org and hkps://keyserver.ubuntu.com as
recommended in the [docker-library faq](https://github.com/docker-library/faq#openpgp--gnupg-keys-and-verification).

Related to https://github.com/docker-library/faq/pull/26