### PR TITLE
Update ubi-minimal base to 8.5

### DIFF
--- a/ubi/Dockerfile
+++ b/ubi/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5
 
 LABEL maintainer="HashiCorp"
 ARG VAULT_VERSION=1.10.0-rc1


### PR DESCRIPTION
UBI 8.4 is failing the RedHat security scan; 8.5 passes. Tested this upgrade in k8s a bit with no issues.