### PR TITLE
update the UBI base image version and tag format

### DIFF
--- a/ubi/Dockerfile
+++ b/ubi/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
 
 LABEL maintainer="HashiCorp"
 ARG VAULT_VERSION=1.11.0-rc1

--- a/ubi/Makefile
+++ b/ubi/Makefile
@@ -6,7 +6,7 @@ export VERSION=1.11.0-rc1
 build: ent-image oss-image fips-ent-image
 
 ent-image: export PROJECT_NAME=vault-enterprise
-ent-image: export TAG_SUFFIX=-ubi-ent
+ent-image: export TAG_SUFFIX=-ent-ubi
 ent-image:
 	docker build --label version=$(VERSION) --build-arg VAULT_VERSION=$(VERSION)+ent --no-cache -t $(REGISTRY_NAME)/$(PROJECT_NAME):$(VERSION)$(TAG_SUFFIX) .
 	@../scripts/tag-images.sh
@@ -37,7 +37,7 @@ ent-push-image: export REGISTRY_KEY=${ENT_REGISTRY_KEY}
 ent-push-image: export VAULT_PID=${ENT_VAULT_PID}
 ent-push-image: export VAULT_VERSION=$(VERSION)
 ent-push-image: export PROJECT_NAME=vault-enterprise
-ent-push-image: export TAG_SUFFIX=-ubi-ent
+ent-push-image: export TAG_SUFFIX=-ent-ubi
 ent-push-image:
 	@./push_image.sh
 


### PR DESCRIPTION
Use ubi-minimal:8.6, and use the same tag format as the vault repo dockerfile (i.e. `<version>-ent-ubi` instead of `<version>-ubi-ent`).

Related to https://github.com/hashicorp/vault/pull/16095

(Just keeping this up to date with [vault's Dockerfile](https://github.com/hashicorp/vault/blob/main/Dockerfile#L74), in the event we need to build the UBI images by hand.)