### PR TITLE
Update to 1.10.10

### DIFF
--- a/0.X/Dockerfile
+++ b/0.X/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.14
 
 # This is the release of Vault to pull in.
-ARG VAULT_VERSION=1.12.2
+ARG VAULT_VERSION=1.10.10
 
 # Create a vault user and group first so the IDs get set the same way,
 # even as the rest of this may change over time.

--- a/0.X/Makefile
+++ b/0.X/Makefile
@@ -1,5 +1,5 @@
 export REGISTRY_NAME?=docker.io/hashicorp
-export VERSION=1.12.2
+export VERSION=1.10.10
 
 .PHONY: build ent-image oss-image xc-prod-image
 

--- a/ubi/Dockerfile
+++ b/ubi/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
 
 LABEL maintainer="HashiCorp"
-ARG VAULT_VERSION=1.12.2
+ARG VAULT_VERSION=1.10.10
 
 # Additional metadata labels used by container registries, platforms
 # and certification scanners.

--- a/ubi/Makefile
+++ b/ubi/Makefile
@@ -1,5 +1,5 @@
 export REGISTRY_NAME?=docker.io/hashicorp
-export VERSION=1.12.2
+export VERSION=1.10.10
 
 .PHONY: build ent-image oss-image
 


### PR DESCRIPTION
Starting with 1.10.10. This might seem weird as it's going down in versions, but that seems to be the way things were done last time:
https://github.com/hashicorp/docker-vault/pull/308/files