### PR TITLE
Build and push s390x multi arch image

### DIFF
--- a/0.X/Dockerfile
+++ b/0.X/Dockerfile
@@ -17,6 +17,7 @@ RUN set -eux; \
         aarch64) ARCH='arm64' ;; \
         x86_64) ARCH='amd64' ;; \
         x86) ARCH='386' ;; \
+        s390x) ARCH='s390x' ;; \
         *) echo >&2 "error: unsupported architecture: $apkArch"; exit 1 ;; \
     esac && \
     VAULT_GPGKEY=C874011F0AB405110D02105534365D9472D7468F; \
@@ -32,6 +33,7 @@ RUN set -eux; \
     test -z "$found" && echo >&2 "error: failed to fetch GPG key $VAULT_GPGKEY" && exit 1; \
     mkdir -p /tmp/build && \
     cd /tmp/build && \
+    if [ "$ARCH" == "s390x" ]; then VAULT_VERSION=${VAULT_VERSION}+ent; fi && \
     wget https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_${ARCH}.zip && \
     wget https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_SHA256SUMS && \
     wget https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_SHA256SUMS.sig && \

--- a/0.X/Makefile
+++ b/0.X/Makefile
@@ -19,7 +19,7 @@ oss-image:
 # This target is used in CI to cross compile vault and vault-ent for 4 different architectures
 # and publish (when XC_PUBLISH="--push") using docker buildx
 xc-prod-image:
-	docker buildx build --platform linux/amd64,linux/arm64,linux/386,linux/arm/v6 \
+	docker buildx build --platform linux/amd64,linux/arm64,linux/386,linux/arm/v6,linux/s390x \
 	--build-arg VAULT_VERSION=$(VERSION)$(VAULT_VERSION_SUFFIX) \
 	--label version=$(VERSION) \
 	$(XC_PUBLISH) \


### PR DESCRIPTION
As Of now, hashicorp/vault image is not available for s390x platform. https://hub.docker.com/r/hashicorp/vault/tags 
Even though binary is built and available as https://releases.hashicorp.com/vault/1.13.1+ent/. so we need to enable s390x docker image with above binary.