### PR TITLE
Use new docker env var for decrypting TLS secret key file

### DIFF
--- a/0.X/docker-entrypoint.sh
+++ b/0.X/docker-entrypoint.sh
@@ -43,6 +43,12 @@ if [ -n "$VAULT_LOCAL_CONFIG" ]; then
     echo "$VAULT_LOCAL_CONFIG" > "$VAULT_CONFIG_DIR/local.json"
 fi
 
+# When enabling TLS and providing a passphrase-protected secret key file,
+# Pass in the VAULT_TLS_KEY_PASSPHRASE environment variable
+if [ -n "$VAULT_TLS_KEY_PASSPHRASE" ]; then
+    echo "Using the provided passphrase to decrypt the secret key file and enable TLS."
+fi
+
 # If the user is trying to run Vault directly with some arguments, then
 # pass them to Vault.
 if [ "${1:0:1}" = '-' ]; then
@@ -101,4 +107,4 @@ if [ "$1" = 'vault' ]; then
     fi
 fi
 
-exec "$@"
+echo "${VAULT_TLS_KEY_PASSPHRASE}" | exec "$@"


### PR DESCRIPTION
Addresses #211 and related to hashicorp/vault issues [7072](https://github.com/hashicorp/vault/issues/7072) and [7074](https://github.com/hashicorp/vault/pull/7074)

New env var `docker run -e "VAULT_TLS_KEY_PASSPHRASE=what-you-provide"` now checked within docker-entrypoint.sh and supplied as vault command via pipe. This allows non-interactive docker deployments of the vault container.